### PR TITLE
:arrowup: Bump flask-cors version to 5.0.0 to mitigate CVE

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ app = "python3 -m flask --app app.app --debug run"
 
 [packages]
 flask = "==3.0.2"
-flask-cors = "==4.0.1"
+flask-cors = "==5.0.0"
 flask-limiter = "==3.5.0"
 govuk-frontend-jinja = "==3.0.0"
 gunicorn = "==22.0.0"


### PR DESCRIPTION
This commit connects to https://github.com/ministryofjustice/operations-engineering/issues/4809
