### PR TITLE
✨ Add Page For Owners

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+exclude_also = 
+    main()

--- a/.github/workflows/cicd-deploy-to-dev.yml
+++ b/.github/workflows/cicd-deploy-to-dev.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 env:
   KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}

--- a/.github/workflows/cicd-deploy-to-dev.yml
+++ b/.github/workflows/cicd-deploy-to-dev.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 env:
   KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}

--- a/app/main/config/routes_config.py
+++ b/app/main/config/routes_config.py
@@ -3,9 +3,11 @@ from flask import Flask
 from app.main.routes.main import main
 from app.main.routes.auth import auth_route
 from app.main.routes.robots import robot_route
+from app.main.routes.owner import owner_route
 
 
 def configure_routes(app: Flask) -> None:
     app.register_blueprint(auth_route, url_prefix="/auth")
+    app.register_blueprint(owner_route, url_prefix="/owner")
     app.register_blueprint(main)
     app.register_blueprint(robot_route)

--- a/app/main/routes/owner.py
+++ b/app/main/routes/owner.py
@@ -1,0 +1,107 @@
+import logging
+from app.main.middleware.auth import requires_auth
+from app.main.services.database_service import DatabaseService
+import plotly.express as px
+import pandas as pd
+from flask import Blueprint, render_template, request
+from collections import Counter
+
+logger = logging.getLogger(__name__)
+
+owner_route = Blueprint("owner_route", __name__)
+
+
+def generate_pie_chart_of_admin_access(repositories: list[dict], selected_owner: str):
+    dataframe = pd.DataFrame(repositories)
+    dataframe["owners"] = dataframe["owners"].apply(
+        lambda owners: [
+            owner["relationship_type"]
+            for owner in owners
+            if "relationship_type" in owner and owner["owner_name"] == selected_owner
+        ]
+        if owners
+        else ["No relationships"]
+    )
+    all_owners = [owner for owners_list in dataframe["owners"] for owner in owners_list]
+    owner_counts = pd.DataFrame(
+        Counter(all_owners).items(), columns=["owners", "count"]
+    )
+
+    fig = px.pie(
+        owner_counts,
+        names="owners",
+        values="count",
+    )
+    return fig.to_html(full_html=False)
+
+
+@owner_route.route("/", methods=["GET"])
+@requires_auth
+def index():
+    database_service = DatabaseService()
+    repositories = database_service.find_all_repositories()
+    owners = database_service.find_all_owners()
+    repository_name = request.args.get("repository-name")
+    selected_owner = request.args.get("owner")
+    selected_access_levels = request.args.getlist("access-levels")
+
+    filtered_repositories = []
+    if selected_owner:
+        for repository in repositories:
+            if "NO_OWNER" in selected_owner and not repository["owners"]:
+                filtered_repositories = filtered_repositories + [repository]
+                continue
+
+            selected_owners_full = []
+            for owner in repository["owners"]:
+                if owner["owner_name"] == selected_owner:
+                    selected_owners_full += [owner]
+                    for owner in selected_owners_full:
+                        has_admin_access = (
+                            True
+                            if "ADMIN_ACCESS" in owner.get("relationship_type")
+                            else False
+                        )
+
+                        if (
+                            "ADMIN" in selected_access_levels
+                            and has_admin_access
+                            or "OTHER" in selected_access_levels
+                            and not has_admin_access
+                        ):
+                            repositories_filtered_by_access_level = (
+                                filtered_repositories + [repository]
+                            )
+                            filtered_repositories = filtered_repositories + [repository]
+                            break
+    else:
+        filtered_repositories = repositories
+
+    filtered_repositories_by_name = []
+    if repository_name:
+        for repository in repositories:
+            if repository_name and repository_name in repository["name"]:
+                filtered_repositories_by_name = filtered_repositories_by_name + [
+                    repository
+                ]
+    else:
+        filtered_repositories_by_name = filtered_repositories
+
+    repositories_filtered_by_access_level = filtered_repositories_by_name
+
+    return render_template(
+        "pages/owner.html",
+        repositories=repositories_filtered_by_access_level,
+        pie_chart_of_admin_access=generate_pie_chart_of_admin_access(
+            repositories_filtered_by_access_level, selected_owner
+        )
+        if repositories_filtered_by_access_level
+        else None,
+        repository_name=repository_name if repository_name else "",
+        selected_owners=selected_owner if selected_owner else "NO_OWNER",
+        owners=owners,
+        access_levels=["ADMIN", "OTHER"],
+        selected_access_levels=selected_access_levels
+        if selected_access_levels
+        else ["ADMIN", "OTHER"],
+    )

--- a/app/templates/pages/owner.html
+++ b/app/templates/pages/owner.html
@@ -1,0 +1,91 @@
+{% extends "components/base.html" %}
+
+{% block pageTitle %}
+    Home
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">Owners</h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h3 class="govuk-heading-l">Repositories by Relationship Type</h3>
+      {{ pie_chart_of_admin_access | safe }}
+    </div>
+  </div>
+
+  <h3 class="govuk-heading-m">Filter Results</h3>
+
+  <form method="get">
+    <div class="moj-filter">
+      <div class="moj-filter__header">
+        <div class="moj-filter__header-title">
+          <h2 class="govuk-heading-m">Filter</h2>
+        </div>
+        <div class="moj-filter__header-action">
+        </div>
+      </div>
+
+      <div class="moj-filter__content">
+        <div class="moj-filter__options">
+          <button type="submit" class="govuk-button" data-module="govuk-button" data-test-id="submit-button">
+            Apply filters
+          </button>
+          <div class="govuk-form-group">
+            <label class="govuk-label" for="sort">
+              Owner
+            </label>
+            <select class="govuk-select" id="owner" name="owner">
+              {% for owner in owners %}
+                <option value="{{ owner }}" {% if owner == selected_owners %} selected {% endif %}>{{ owner }}</option>
+              {% endfor %}
+              <option value="NO_OWNER"  {% if "NO_OWNER" == selected_owners %} selected {% endif %} >No Owner</option>
+            </select>
+          </div>
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-label--m" for="repository-name">
+              Repository Name
+            </label>
+            <input class="govuk-input" id="repository-name" name="repository-name" type="text" value="{{ repository_name }}">
+          </div>
+          <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                Relationship Types
+              </legend>
+              {% for access_level in access_levels %}
+              <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="{{ access_level }}" name="access-levels" type="checkbox" value="{{ access_level }}" {% if access_level in selected_access_levels %} checked {% endif %}>
+                  <label class="govuk-label govuk-checkboxes__label" for="{{ access_level }}">
+                    {{ access_level }}
+                  </label>
+                </div>
+              </div>
+              {% endfor %}
+            </fieldset>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+
+  <table class="govuk-table" data-module="moj-sortable-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header" aria-sort="ascending">Name</th>
+        <th scope="col" class="govuk-table__header" aria-sort="none">Owners</th>
+      </tr>
+    </thead>
+
+    <tbody class="govuk-table__body">
+      {% for repository in repositories %}
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><a href="https://github.com/ministryofjustice/{{ repository["name"] }}" rel="noreferrer noopener" target="_blank" class="govuk-link">{{ repository["name"] }}</a></td>
+          <td class="govuk-table__cell">{% for owner in repository["owners"] %} {{ owner["owner_name"] }} has {{ owner["relationship_type"] }}{% if loop.nextitem %}, {% endif %} {% endfor %}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+{% endblock %}


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4870
- To add a new page that focuses on the information a single Owner/Business unit would want to see

## ♻️ What's changed

- Added a new page which allows users to select the owner, search for a specific repository by name, filter by the owners relationship to the repository and a pie chart to display the percentage of Admin Access to their estate

## 📝 Notes

- Not removed any features from the main page, or linking to this page yet - going to see how it looks live before a change anything more

<img width="524" alt="image" src="https://github.com/user-attachments/assets/09925797-818a-43f2-9173-7defcf57dac9">
