### PR TITLE
✨ Add Option to Exlude Other Relationships When Admin Exists

### DIFF
--- a/.github/workflows/cicd-deploy-to-dev.yml
+++ b/.github/workflows/cicd-deploy-to-dev.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 env:
   KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}

--- a/.github/workflows/cicd-deploy-to-dev.yml
+++ b/.github/workflows/cicd-deploy-to-dev.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 env:
   KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}

--- a/app/main/services/database_service.py
+++ b/app/main/services/database_service.py
@@ -183,7 +183,7 @@ class DatabaseService:
             panda_owner_id,
         )
         self.add_relationship(
-            "STUBBED_OWNER_HAS_ADMIN_ACCESS",
+            "STUBBED_OTHER",
             operations_engineering_testing_asset_id,
             panda_owner_id,
         )

--- a/app/templates/pages/owner.html
+++ b/app/templates/pages/owner.html
@@ -65,6 +65,20 @@
               {% endfor %}
             </fieldset>
           </div>
+          <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                Options
+              </legend>
+              <div class="govuk-checkboxes govuk-checkboxes--small" data-module="govuk-checkboxes">
+                <div class="govuk-checkboxes__item">
+                  <input class="govuk-checkboxes__input" id="exclude_other_relationships_where_admins_exist" name="exclude_other_relationships_where_admins_exist" type="checkbox" value="true" {% if exclude_other_relationships_where_admins_exist %} checked {% endif %}>
+                  <label class="govuk-label govuk-checkboxes__label" for="exclude_other_relationships_where_admins_exist">Exclude Other Relationships When Admins Exist</label>
+                </div>
+              </div>
+            </fieldset>
+          </div>
+
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 👀 Purpose

- In relation to https://github.com/ministryofjustice/operations-engineering/issues/4870
- To allow owners to filter out any repositories that they have a loose connection to but another owner is the administrator of (helps filter out Platform related repositories)

## ♻️ What's changed

- Added a new option to "Exclude Other Relationships When Admins Exist"

## 📝 Notes

<img width="973" alt="image" src="https://github.com/user-attachments/assets/df9e7fc3-15cc-48e4-9fc6-8c38cfaf2077">
